### PR TITLE
Inverse Vulkan Z-Axis - Prevent Mirrored Aircraft Labels

### DIFF
--- a/src/2D.cpp
+++ b/src/2D.cpp
@@ -99,8 +99,13 @@ static bool ConvertTo2d(const float x, const float y, const float z,
     out_x = (int)std::lround(gScreenW * (afNdc[0] * 0.5f + 0.5f));
     out_y = (int)std::lround(gScreenH * (afNdc[1] * 0.5f + 0.5f));
     
-    // afNdc[2] is basically the Z value, with -1 <= Z <= 1 meaning: visible
-    return -1.0f <= afNdc[2] && afNdc[2] <= 1.0;
+    // afNdc[2] is basically the Z value
+    if (UsingModernGraphicsDriver())
+        // Vulkan z-axis NDC is [0,1]
+        return 0.0f <= afNdc[2] && afNdc[2] <= 1.0f;
+    else
+        // OGL z-axis is [-1,1]
+        return -1.0f <= afNdc[2] && afNdc[2] <= 1.0;
 }
 
 //


### PR DESCRIPTION
Vulkan's z-axis is an inverse of OpenGL's z-axis [0,1] as opposed to [-1,1]. 

This PR addresses an issue with aircraft labels being mirrored behind the camera view (i.e. by rotating the camera 180°, the labels are visible still).

I do not have access to X-Plane on MacOS, so I'm not sure if this change would adversely affect label rendering with the Metal driver.