### PR TITLE
Fix data race during Instance Deletion.

### DIFF
--- a/src/Aircraft.cpp
+++ b/src/Aircraft.cpp
@@ -615,8 +615,9 @@ void Aircraft::DestroyInstances ()
 
     if (!listInst.empty()) {
         while (!listInst.empty()) {
-            XPLMDestroyInstance(listInst.back());
+            XPLMInstanceRef tem = listInst.back();
             listInst.pop_back();
+            XPLMDestroyInstance(tem);
         }
         LOG_MSG(logDEBUG, DEBUG_INSTANCE_DESTRYD, modeS_id);
     }


### PR DESCRIPTION
So I could be totally off base here.. but it looks like in Aircraft::DestroyInstances(), you call XPLMDestroyInstance, then you remove it from the list in lines 618 & 619.. assuming DoMove is being called on the aircraft in another thread at the same time, timed exactly between these two lines, it's possible for you to end up calling XPLMInstanceSetPosition on line 505, with an invalid instance handle, which if xPlane is using as a pointer, would explain the bogus issues we're seeing.. it's not the data pointers that are invalid, it's the instance   #23 