### PR TITLE
v3.3.1 Fixes: Freeze in XP12.0.8 / Sound Crackling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ else()
 endif()
 
 project(XPMP2
-        VERSION 3.3.0
+        VERSION 3.3.1
         DESCRIPTION "Multiplayer library for X-Plane 11 and 12")
 
 # Provide compile macros from the above project version definition

--- a/XPMP2.xcodeproj/project.pbxproj
+++ b/XPMP2.xcodeproj/project.pbxproj
@@ -481,7 +481,7 @@
 				);
 				XPMP2_VER_MAJOR = 3;
 				XPMP2_VER_MINOR = 3;
-				XPMP2_VER_PATCH = 0;
+				XPMP2_VER_PATCH = 1;
 				XPSDK_ROOT = lib/SDK;
 			};
 			name = Debug;
@@ -583,7 +583,7 @@
 				);
 				XPMP2_VER_MAJOR = 3;
 				XPMP2_VER_MINOR = 3;
-				XPMP2_VER_PATCH = 0;
+				XPMP2_VER_PATCH = 1;
 				XPSDK_ROOT = lib/SDK;
 			};
 			name = Release;

--- a/src/AIMultiplayer.cpp
+++ b/src/AIMultiplayer.cpp
@@ -749,26 +749,24 @@ int AIMultiControlPlaneCount(
 //
 
 /// @brief Resets all actual values of the AI/multiplayer dataRefs of one plane to something initial
-/// @note There as pending bug, filed as XPD-13332, which affects this function with XP12 on Mac.
+/// @note There as pending bug, filed as XPD-13332, which affects this function with XP12.
 ///       X-Plane 12 can freeze since b5 when clearing Multiplayer positions to zero.
 /// @see https://forums.x-plane.org/index.php?/forums/topic/276319-xp12-on-mac-since-b5-freeze-upon-tcas-activation/
+/// @see also https://forums.x-plane.org/index.php?/forums/topic/296584-livetraffic-freezes-xp-1208beta1-on-taking-over-tcas/
+///      reporting the same issue for Linux, so we switch initializing off completely.
 void AIMultiClearAIDataRefs (multiDataRefsTy& drM,
                              bool bDeactivateToZero)
 {
     // not ok dataRefs?
     if (!drM) return;
     
-#if APL
-    // Apple Workaround for XP12: Don't init position, otherwise may freeze
+    // XPD-13332 Workaround for XP12: Don't init position, otherwise may freeze
     if (glob.verXPlane < 12000) {
-#endif
-    // either a "far away" location or standard 0, which is, however, a valid location somewhere!
-    XPLMSetDataf(drM.X, bDeactivateToZero ? 0.0f : FAR_AWAY_VAL_GL);
-    XPLMSetDataf(drM.Y, bDeactivateToZero ? 0.0f : FAR_AWAY_VAL_GL);
-    XPLMSetDataf(drM.Z, bDeactivateToZero ? 0.0f : FAR_AWAY_VAL_GL);
-#if APL
+        // either a "far away" location or standard 0, which is, however, a valid location somewhere!
+        XPLMSetDataf(drM.X, bDeactivateToZero ? 0.0f : FAR_AWAY_VAL_GL);
+        XPLMSetDataf(drM.Y, bDeactivateToZero ? 0.0f : FAR_AWAY_VAL_GL);
+        XPLMSetDataf(drM.Z, bDeactivateToZero ? 0.0f : FAR_AWAY_VAL_GL);
     }
-#endif
 
     XPLMSetDataf(drM.v_x, 0.0f);                // zero speed
     XPLMSetDataf(drM.v_y, 0.0f);

--- a/src/SoundFMOD.h
+++ b/src/SoundFMOD.h
@@ -92,6 +92,8 @@ public:
 
     /// Play a new sound, returns an id for that sound
     uint64_t Play (const std::string& sndName, float vol, const Aircraft& ac) override;
+    /// Unpause a sound, which got started in a paused state to avoid crackling
+    void Unpause (uint64_t sndId) override;
     /// Stop the sound
     void Stop (uint64_t sndId) override;
     /// Update sound's position and orientation


### PR DESCRIPTION
- Reduce audio crackling upon creation of planes by starting all sounds in a paused state. This code was in earlier but got removed when incorporating XP's Sound API. This fix only works with the FMOD library compiled/linked into XPMP2 as XP's Sound API doesn't provide (un)pause functionality.
- Fix freeze in XP12.0.8 with TCAS on that was [reported on Linux](https://forums.x-plane.org/index.php?/forums/topic/296584-livetraffic-freezes-xp-1208beta1-on-taking-over-tcas/).