### PR TITLE
v3.6.1 Fix CTD in XP12.4.3 due to in-thread  of XPLMIsFeatureEnabled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         cp -a ./inc deploy-lib
         mv ${{ steps.build.outputs.lib-file-name }} deploy-lib/lib/lin
     - name: Upload XPMP2 lib
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: XPMP2-lib-lin
         path: deploy-lib/*        # this way we keep the folder structure in the artifact
@@ -62,7 +62,7 @@ jobs:
         mkdir -p deploy-lib/lib
         mv ${{ steps.build.outputs.lib-file-name }} deploy-lib/lib
     - name: Upload XPMP2 Framework
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: XPMP2-lib-mac
         path: deploy-lib/*        # this way we keep the folder structure in the artifact
@@ -90,7 +90,7 @@ jobs:
           cp ${{ steps.build.outputs.pdb-file-name }} deploy-lib/lib/win
         fi
     - name: Upload XPMP2 lib
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: XPMP2-lib-win
         path: deploy-lib/*        # this way we keep the folder structure in the artifact
@@ -116,7 +116,7 @@ jobs:
         mkdir -p deploy-lib/lib/win-dbg
         cp ${{ steps.build.outputs.lib-file-name }} deploy-lib/lib/win-dbg
     - name: Upload XPMP2 lib
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: XPMP2-lib-win-dbg
         path: deploy-lib/*        # this way we keep the folder structure in the artifact
@@ -147,7 +147,7 @@ jobs:
           cp ${{ steps.build.outputs.dll-file-name }} deploy-lib/lib/win-dll
         fi
     - name: Upload XPMP2 lib
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: XPMP2-lib-win-dll
         path: deploy-lib/*        # this way we keep the folder structure in the artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout Code
-      uses: actions/checkout          # must checkout before we can use our own actions
+      uses: actions/checkout@v5       # must checkout before we can use our own actions
     - name: Build
       uses: ./.github/actions/build-lin
       id: build
@@ -49,7 +49,7 @@ jobs:
     runs-on: macos-14
     steps:
     - name: Checkout Code
-      uses: actions/checkout          # must checkout before we can use our own actions
+      uses: actions/checkout@v5       # must checkout before we can use our own actions
     - name: Build
       uses: ./.github/actions/build-mac
       id: build
@@ -74,7 +74,7 @@ jobs:
     runs-on: windows-2022
     steps:
     - name: Checkout Code
-      uses: actions/checkout          # must checkout before we can use our own actions
+      uses: actions/checkout@v5       # must checkout before we can use our own actions
     - name: Build
       uses: ./.github/actions/build-win
       id: build
@@ -102,7 +102,7 @@ jobs:
     runs-on: windows-2022
     steps:
     - name: Checkout Code
-      uses: actions/checkout          # must checkout before we can use our own actions
+      uses: actions/checkout@v5       # must checkout before we can use our own actions
     - name: Build
       uses: ./.github/actions/build-win
       id: build
@@ -128,7 +128,7 @@ jobs:
     runs-on: windows-2022
     steps:
     - name: Checkout Code
-      uses: actions/checkout          # must checkout before we can use our own actions
+      uses: actions/checkout@v5       # must checkout before we can use our own actions
     - name: Build
       uses: ./.github/actions/build-win
       id: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4       # must checkout before we can use our own actions
+      uses: actions/checkout          # must checkout before we can use our own actions
     - name: Build
       uses: ./.github/actions/build-lin
       id: build
@@ -49,7 +49,7 @@ jobs:
     runs-on: macos-14
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4       # must checkout before we can use our own actions
+      uses: actions/checkout          # must checkout before we can use our own actions
     - name: Build
       uses: ./.github/actions/build-mac
       id: build
@@ -74,7 +74,7 @@ jobs:
     runs-on: windows-2022
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4       # must checkout before we can use our own actions
+      uses: actions/checkout          # must checkout before we can use our own actions
     - name: Build
       uses: ./.github/actions/build-win
       id: build
@@ -102,7 +102,7 @@ jobs:
     runs-on: windows-2022
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4       # must checkout before we can use our own actions
+      uses: actions/checkout          # must checkout before we can use our own actions
     - name: Build
       uses: ./.github/actions/build-win
       id: build
@@ -128,7 +128,7 @@ jobs:
     runs-on: windows-2022
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4       # must checkout before we can use our own actions
+      uses: actions/checkout          # must checkout before we can use our own actions
     - name: Build
       uses: ./.github/actions/build-win
       id: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,8 +187,8 @@ else()
         # Multi-threaded (/MD), full optimization (/O2), debug info into separate -pdb file
         target_compile_options(XPMP2 PRIVATE /MD /O2 /Zi)
     else()
-        # Full optimizations (-O3), no debug info, position-independent code (-fPIC)
-        target_compile_options(XPMP2 PRIVATE -O3 -fPIC)
+        # Full optimizations (-O3), no debug info, position-independent code (-fPIC), minimal debug info for stack traces
+        target_compile_options(XPMP2 PRIVATE -O3 -fPIC -g1)
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 option(XPMP2_BUILD_SHARED_LIBS "Build XPMP2 as a shared libraries" OFF)
 
 project(XPMP2
-        VERSION 3.6.0
+        VERSION 3.6.1
         DESCRIPTION "Multiplayer library for X-Plane 11 and 12")
 
 # Source file list

--- a/inc/XPMPAircraft.h
+++ b/inc/XPMPAircraft.h
@@ -85,6 +85,8 @@ constexpr double M_per_FT   = 0.3048;   // meter per 1 foot
 constexpr int M_per_NM      = 1852;     // meter per one nautical mile
 /// Convert m/s to knots
 constexpr double KT_per_M_per_S = 1.94384;  // 1m/s = 1.94384kt
+/// Convert m/s to feet/min (for vertical speeds)
+constexpr double FT_p_MIN_per_M_p_S = 196.85039370079;
 /// @brief standard gravitational acceleration [m/s²]
 /// @see https://en.wikipedia.org/wiki/Gravity_of_Earth
 constexpr float G_EARTH     = 9.80665f;

--- a/inc/XPMPAircraft.h
+++ b/inc/XPMPAircraft.h
@@ -287,6 +287,7 @@ protected:
     bool bValid                 = true;     ///< is this object valid? (Will be reset in case of exceptions)
     bool bVisible               = true;     ///< Shall this plane be drawn at the moment and be visible to TCAS/interfaces?
     bool bRender                = true;     ///< Shall the CSL model be drawn in 3D world? (if !bRender && bVivile then still visible on TCAS/interfaces, Remote Client uses this for local senders' planes to take over TCAS but not drawing)
+    bool bWriteTCASDataRefs     = false;    ///< Time to write the less often updated TCAS target dataRefs?
     
     XPMP2::CSLModel*    pCSLMdl = nullptr;  ///< the CSL model in use
     int                 matchQuality = -1;  ///< quality of the match with the CSL model
@@ -294,7 +295,7 @@ protected:
     
     // this is data from about a second ago to calculate cartesian velocities
     float               prev_x = 0.0f, prev_y = 0.0f, prev_z = 0.0f;
-    float               prev_ts = 0.0f;     ///< last update of `prev_x/y/z` in XP's network time
+    float               prev_ts = 0.0f;     ///< last update of `prev_x/y/z` in seconds CPU time since plugin start
     float               gs_kn = 0.0f;       /// ground speed in [kn] based on above v_x/z
     
     /// Reverse-engineered lat/lon/alt, updated only once per second
@@ -756,13 +757,15 @@ protected:
     /// Internal: This puts the instance into XP's sky and makes it move
     void DoMove ();
     /// Internal: Processes once every second only stuff that doesn't require being computed every flight loop
-    void DoEverySecondUpdates (float now);
+    void DoEverySecondUpdates (float now, float secSinceBase);
     /// Internal: Create/move contrails, implemented in Contrail.cpp
     void ContrailMove ();
     /// Internal: (Re)Assess if contrails are to be created
     void ContrailAutoUpdate ();
     /// Internal: Update the plane's distance/bearing from the camera location
     void UpdateDistBearingCamera (const XPLMCameraPosition_t& posCam);
+    /// Internal: Update cartesian velocities (about every second)
+    void UpdateVelocities (float d_t);
     /// Clamp to ground: Make sure the plane is not below ground, corrects Aircraft::drawInfo if needed.
     void ClampToGround ();
     /// Create the instances required to represent the plane, return if successful

--- a/src/AIMultiplayer.cpp
+++ b/src/AIMultiplayer.cpp
@@ -479,20 +479,21 @@ size_t AIUpdateTCASTargets ()
                 if (ac.prev_ts > 0.0001f) {
                     // yes, so we can calculate velocity
                     const float d_t = secSinceBase - ac.prev_ts;                 // time that had passed in seconds
-                    const float d_x = ac.drawInfo.x - ac.prev_x;
-                    const float d_y = ac.drawInfo.y - ac.prev_y;
-                    const float d_z = ac.drawInfo.z - ac.prev_z;
+                    ac.v_x = (ac.drawInfo.x - ac.prev_x) / d_t;
+                    ac.v_y = (ac.drawInfo.y - ac.prev_y) / d_t;
+                    ac.v_z = (ac.drawInfo.z - ac.prev_z) / d_t;
+
                     // horizontal movement
-                    float f = d_x / d_t;
-                    XPLMSetDatavf(drTcasVX, &f, int(slot), 1);
-                    f = d_z / d_t;
-                    XPLMSetDatavf(drTcasVZ, &f, int(slot), 1);
+                    XPLMSetDatavf(drTcasVX, &ac.v_x, int(slot), 1);
+                    XPLMSetDatavf(drTcasVZ, &ac.v_z, int(slot), 1);
+                    // based on horizontal coordinates calculate a (rough) ground speed
+                    ac.gs_kn = std::sqrt(ac.v_x * ac.v_x + ac.v_z * ac.v_z) * float(KT_per_M_per_S);
+
                     // vertical movement (roughly...y is not exact, but let's keep things simple here)
-                    f = d_y / d_t;
-                    XPLMSetDatavf(drTcasVY, &f, int(slot), 1);
+                    XPLMSetDatavf(drTcasVY, &ac.v_y, int(slot), 1);
                     // convert from m/s to ft/min
-                    f *= 60.0f / float(M_per_FT);
-                    XPLMSetDatavf(drTcasVertSpeed, &f, int(slot), 1);
+                    float vertSpd = ac.v_y * float(KT_per_M_per_S);
+                    XPLMSetDatavf(drTcasVertSpeed, &vertSpd, int(slot), 1);
                 }
                 ac.prev_x = ac.drawInfo.x;
                 ac.prev_y = ac.drawInfo.y;

--- a/src/AIMultiplayer.cpp
+++ b/src/AIMultiplayer.cpp
@@ -697,7 +697,7 @@ void AIMultiUpdate ()
             // (these excludes invisible planes and those with transponder off)
             if (ac.ShowAsAIPlane())
                 // Priority distance means that we add artificial distance for higher-numbered AI priorities
-                gMapAcByDist.emplace(ac.GetCameraDist() + ac.aiPrio * AI_PRIO_MULTIPLIER,
+                gMapAcByDist.emplace(ac.GetCameraDist() + float(ac.aiPrio * AI_PRIO_MULTIPLIER),
                                      ac.GetModeS_ID());
             else
                 // for non-shown aircraft make sure no slot is remembered

--- a/src/AIMultiplayer.cpp
+++ b/src/AIMultiplayer.cpp
@@ -297,7 +297,7 @@ size_t AIUpdateMultiplayerDataRefs()
                     XPLMSetDataf(mdr.v_y, ac.v_y = (ac.drawInfo.y - ac.prev_y) / d_s);
                     XPLMSetDataf(mdr.v_z, ac.v_z = (ac.drawInfo.z - ac.prev_z) / d_s);
                     // based on horizontal coordinates calculate a (rough) ground speed
-                    ac.gs_kn = std::sqrt(ac.v_x*ac.v_x + ac.v_z*ac.v_z) * float(KT_per_M_per_S);
+                    ac.gs_kn = std::hypot(ac.v_x, ac.v_z) * float(KT_per_M_per_S);
                 }
                 ac.prev_x = ac.drawInfo.x;
                 ac.prev_y = ac.drawInfo.y;
@@ -487,7 +487,7 @@ size_t AIUpdateTCASTargets ()
                     XPLMSetDatavf(drTcasVX, &ac.v_x, int(slot), 1);
                     XPLMSetDatavf(drTcasVZ, &ac.v_z, int(slot), 1);
                     // based on horizontal coordinates calculate a (rough) ground speed
-                    ac.gs_kn = std::sqrt(ac.v_x * ac.v_x + ac.v_z * ac.v_z) * float(KT_per_M_per_S);
+                    ac.gs_kn = std::hypot(ac.v_x, ac.v_z) * float(KT_per_M_per_S);
 
                     // vertical movement (roughly...y is not exact, but let's keep things simple here)
                     XPLMSetDatavf(drTcasVY, &ac.v_y, int(slot), 1);

--- a/src/AIMultiplayer.cpp
+++ b/src/AIMultiplayer.cpp
@@ -210,6 +210,9 @@ static float tLastSlotSwitching = 0.0f;
 // How many planes did we produce last cycle?
 static size_t numTargetsLastTime = 0;
 
+/// Base time for storing time differences for calculating cartesian speeds
+static const std::chrono::system_clock::time_point baseTimePt = std::chrono::system_clock::now();
+
 //
 // MARK: Aircraft functions related to TCAS
 //
@@ -283,13 +286,13 @@ size_t AIUpdateMultiplayerDataRefs()
             // For performance reasons and because differences (cartesian velocity)
             // are smoother if calculated over "longer" time frames,
             // the following updates are done about every second only
-            const float now = GetMiscNetwTime();
-            if (bSlotChanged || now >= ac.prev_ts + 1.0f)
+            const float secSinceBase = std::chrono::duration<float>(std::chrono::system_clock::now() - baseTimePt).count();
+            if (bSlotChanged || secSinceBase >= ac.prev_ts + 1.0f)
             {
                 // do we have any prev x/y/z values at all?
                 if (ac.prev_ts > 0.0001f) {
                     // yes, so we can calculate velocity
-                    const float d_s = now - ac.prev_ts;                 // time that had passed in seconds
+                    const float d_s = secSinceBase - ac.prev_ts;                 // time that had passed in seconds
                     XPLMSetDataf(mdr.v_x, ac.v_x = (ac.drawInfo.x - ac.prev_x) / d_s);
                     XPLMSetDataf(mdr.v_y, ac.v_y = (ac.drawInfo.y - ac.prev_y) / d_s);
                     XPLMSetDataf(mdr.v_z, ac.v_z = (ac.drawInfo.z - ac.prev_z) / d_s);
@@ -299,7 +302,7 @@ size_t AIUpdateMultiplayerDataRefs()
                 ac.prev_x = ac.drawInfo.x;
                 ac.prev_y = ac.drawInfo.y;
                 ac.prev_z = ac.drawInfo.z;
-                ac.prev_ts = now;
+                ac.prev_ts = secSinceBase;
 
                 // configuration (cont.)
                 XPLMSetDataf(mdr.spoiler,       ac.v[V_CONTROLS_SPOILER_RATIO]);
@@ -353,8 +356,7 @@ size_t AIUpdateTCASTargets ()
     static std::vector<float> vX;
     static std::vector<float> vY;          
     static std::vector<float> vZ;          
-    static std::vector<float> vVertSpeed;  
-    static std::vector<float> vHeading;    
+    static std::vector<float> vHeading;
     static std::vector<float> vPitch;      
     static std::vector<float> vRoll;       
     static std::vector<int>   vGrnd;
@@ -384,7 +386,6 @@ size_t AIUpdateTCASTargets ()
     vX.assign(numSlots, 0);
     vY.assign(numSlots, 0);
     vZ.assign(numSlots, 0);
-    vVertSpeed.assign(numSlots, 0);
     vHeading.assign(numSlots, 0);
     vPitch.assign(numSlots, 0);
     vRoll.assign(numSlots, 0);
@@ -406,7 +407,8 @@ size_t AIUpdateTCASTargets ()
     vWakeAoA.assign(numSlots, 0);
     vWakeLift.assign(numSlots, 0);
 
-    const float now = GetMiscNetwTime();
+    // Seconds passed since plugin load
+    const float secSinceBase = std::chrono::duration<float>(std::chrono::system_clock::now() - baseTimePt).count();
 
     // Loop over all filled slots
     size_t slot = 1;
@@ -471,31 +473,31 @@ size_t AIUpdateTCASTargets ()
             // are smoother if calculated over "longer" time frames,
             // the following updates are done about every second only,
             // or if the a/c changed slot (to make sure all dataRef values are in synch)
-            if (bSlotChanged || (now >= ac.prev_ts + 1.0f))
+            if (bSlotChanged || (secSinceBase >= ac.prev_ts + 1.0f))
             {
                 // do we have any prev x/y/z values at all?
                 if (ac.prev_ts > 0.0001f) {
                     // yes, so we can calculate velocity
-                    const float d_t = now - ac.prev_ts;                 // time that had passed in seconds
+                    const float d_t = secSinceBase - ac.prev_ts;                 // time that had passed in seconds
                     const float d_x = ac.drawInfo.x - ac.prev_x;
                     const float d_y = ac.drawInfo.y - ac.prev_y;
                     const float d_z = ac.drawInfo.z - ac.prev_z;
+                    // horizontal movement
                     float f = d_x / d_t;
                     XPLMSetDatavf(drTcasVX, &f, int(slot), 1);
-                    f = d_y / d_t;
-                    XPLMSetDatavf(drTcasVY, &f, int(slot), 1);
                     f = d_z / d_t;
                     XPLMSetDatavf(drTcasVZ, &f, int(slot), 1);
-                    
-                    // vertical speed (roughly...y is not exact, but let's keep things simple here),
+                    // vertical movement (roughly...y is not exact, but let's keep things simple here)
+                    f = d_y / d_t;
+                    XPLMSetDatavf(drTcasVY, &f, int(slot), 1);
                     // convert from m/s to ft/min
-                    f = (d_y / d_t) * (60.0f / float(M_per_FT));
+                    f *= 60.0f / float(M_per_FT);
                     XPLMSetDatavf(drTcasVertSpeed, &f, int(slot), 1);
                 }
                 ac.prev_x = ac.drawInfo.x;
                 ac.prev_y = ac.drawInfo.y;
                 ac.prev_z = ac.drawInfo.z;
-                ac.prev_ts = now;
+                ac.prev_ts = secSinceBase;
                 
                 // Flight or tail number as FlightID
                 char s[8];
@@ -529,16 +531,35 @@ size_t AIUpdateTCASTargets ()
         CATCH_AC(ac)
     }
     
+    // Reduce 'slot' to the actual number of planes being shown
+    --slot;
+    
+    // Validation if all ModeS ids are set properly
+    if (logDEBUG >= glob.logLvl) {
+        const auto it = std::find(vModeS.begin(), vModeS.end(), 0);             // find the first zer0
+        if (std::distance(vModeS.begin(), it) < long(slot)) {                   // must not be in the first `slot` elements!
+            std::string s;
+            std::for_each_n(vModeS.begin(), slot,
+                            [&s](int modeSID)
+            {
+                s += std::to_string(modeSID);
+                s += ", ";
+            });
+            if (s.length() >= 2) { s.pop_back(); s.pop_back(); }
+            LOG_MSG(logWARN, "Have %zu slots, found a zero too early:\n%s",
+                    slot, s.c_str());
+        }
+    }
+    
     // Feed the dataRefs to X-Plane for TCAS target tracking
 #define SET_DR(ty, dr) XPLMSetData##ty(drTcas##dr, v##dr.data(), 1, (int)v##dr.size())
-#define SET_DR_ONLY_USED(ty, dr) XPLMSetData##ty(drTcas##dr, v##dr.data(), 1, (int)(slot-1))
+#define SET_DR_ONLY_USED(ty, dr) if (slot>0) XPLMSetData##ty(drTcas##dr, v##dr.data(), 1, (int)slot)
     SET_DR(vi, ModeS);
     SET_DR(vi, ModeC);
     SET_DR(vi, SsrMode);
     SET_DR_ONLY_USED(vf, X);            // must not set/clean unused slots here, otherwise XP12.4+ throws "Traffic plugin error...gave us target with no ID"
     SET_DR_ONLY_USED(vf, Y);
     SET_DR_ONLY_USED(vf, Z);
-    SET_DR(vf, VertSpeed);
     SET_DR(vf, Heading);
     SET_DR(vf, Pitch);
     SET_DR(vf, Roll);

--- a/src/AIMultiplayer.cpp
+++ b/src/AIMultiplayer.cpp
@@ -210,9 +210,6 @@ static float tLastSlotSwitching = 0.0f;
 // How many planes did we produce last cycle?
 static size_t numTargetsLastTime = 0;
 
-/// Base time for storing time differences for calculating cartesian speeds
-static const std::chrono::system_clock::time_point baseTimePt = std::chrono::system_clock::now();
-
 //
 // MARK: Aircraft functions related to TCAS
 //
@@ -286,23 +283,12 @@ size_t AIUpdateMultiplayerDataRefs()
             // For performance reasons and because differences (cartesian velocity)
             // are smoother if calculated over "longer" time frames,
             // the following updates are done about every second only
-            const float secSinceBase = std::chrono::duration<float>(std::chrono::system_clock::now() - baseTimePt).count();
-            if (bSlotChanged || secSinceBase >= ac.prev_ts + 1.0f)
+            if (bSlotChanged || ac.bWriteTCASDataRefs)
             {
-                // do we have any prev x/y/z values at all?
-                if (ac.prev_ts > 0.0001f) {
-                    // yes, so we can calculate velocity
-                    const float d_s = secSinceBase - ac.prev_ts;                 // time that had passed in seconds
-                    XPLMSetDataf(mdr.v_x, ac.v_x = (ac.drawInfo.x - ac.prev_x) / d_s);
-                    XPLMSetDataf(mdr.v_y, ac.v_y = (ac.drawInfo.y - ac.prev_y) / d_s);
-                    XPLMSetDataf(mdr.v_z, ac.v_z = (ac.drawInfo.z - ac.prev_z) / d_s);
-                    // based on horizontal coordinates calculate a (rough) ground speed
-                    ac.gs_kn = std::hypot(ac.v_x, ac.v_z) * float(KT_per_M_per_S);
-                }
-                ac.prev_x = ac.drawInfo.x;
-                ac.prev_y = ac.drawInfo.y;
-                ac.prev_z = ac.drawInfo.z;
-                ac.prev_ts = secSinceBase;
+                // cartesian velocities
+                XPLMSetDataf(mdr.v_x, ac.v_x);
+                XPLMSetDataf(mdr.v_y, ac.v_y);
+                XPLMSetDataf(mdr.v_z, ac.v_z);
 
                 // configuration (cont.)
                 XPLMSetDataf(mdr.spoiler,       ac.v[V_CONTROLS_SPOILER_RATIO]);
@@ -407,9 +393,6 @@ size_t AIUpdateTCASTargets ()
     vWakeAoA.assign(numSlots, 0);
     vWakeLift.assign(numSlots, 0);
 
-    // Seconds passed since plugin load
-    const float secSinceBase = std::chrono::duration<float>(std::chrono::system_clock::now() - baseTimePt).count();
-
     // Loop over all filled slots
     size_t slot = 1;
     for (; slot < gSlots.size() && gSlots[slot] != nullptr; ++slot)
@@ -473,32 +456,17 @@ size_t AIUpdateTCASTargets ()
             // are smoother if calculated over "longer" time frames,
             // the following updates are done about every second only,
             // or if the a/c changed slot (to make sure all dataRef values are in synch)
-            if (bSlotChanged || (secSinceBase >= ac.prev_ts + 1.0f))
+            if (bSlotChanged || ac.bWriteTCASDataRefs)
             {
-                // do we have any prev x/y/z values at all?
-                if (ac.prev_ts > 0.0001f) {
-                    // yes, so we can calculate velocity
-                    const float d_t = secSinceBase - ac.prev_ts;                 // time that had passed in seconds
-                    ac.v_x = (ac.drawInfo.x - ac.prev_x) / d_t;
-                    ac.v_y = (ac.drawInfo.y - ac.prev_y) / d_t;
-                    ac.v_z = (ac.drawInfo.z - ac.prev_z) / d_t;
+                // horizontal movement
+                XPLMSetDatavf(drTcasVX, &ac.v_x, int(slot), 1);
+                XPLMSetDatavf(drTcasVZ, &ac.v_z, int(slot), 1);
 
-                    // horizontal movement
-                    XPLMSetDatavf(drTcasVX, &ac.v_x, int(slot), 1);
-                    XPLMSetDatavf(drTcasVZ, &ac.v_z, int(slot), 1);
-                    // based on horizontal coordinates calculate a (rough) ground speed
-                    ac.gs_kn = std::hypot(ac.v_x, ac.v_z) * float(KT_per_M_per_S);
-
-                    // vertical movement (roughly...y is not exact, but let's keep things simple here)
-                    XPLMSetDatavf(drTcasVY, &ac.v_y, int(slot), 1);
-                    // convert from m/s to ft/min
-                    float vertSpd = ac.v_y * float(FT_p_MIN_per_M_p_S);
-                    XPLMSetDatavf(drTcasVertSpeed, &vertSpd, int(slot), 1);
-                }
-                ac.prev_x = ac.drawInfo.x;
-                ac.prev_y = ac.drawInfo.y;
-                ac.prev_z = ac.drawInfo.z;
-                ac.prev_ts = secSinceBase;
+                // vertical movement (roughly...y is not exact, but let's keep things simple here)
+                XPLMSetDatavf(drTcasVY, &ac.v_y, int(slot), 1);
+                // convert from m/s to ft/min
+                float vertSpd = ac.v_y * float(FT_p_MIN_per_M_p_S);
+                XPLMSetDatavf(drTcasVertSpeed, &vertSpd, int(slot), 1);
                 
                 // Flight or tail number as FlightID
                 char s[8];

--- a/src/AIMultiplayer.cpp
+++ b/src/AIMultiplayer.cpp
@@ -492,7 +492,7 @@ size_t AIUpdateTCASTargets ()
                     // vertical movement (roughly...y is not exact, but let's keep things simple here)
                     XPLMSetDatavf(drTcasVY, &ac.v_y, int(slot), 1);
                     // convert from m/s to ft/min
-                    float vertSpd = ac.v_y * float(KT_per_M_per_S);
+                    float vertSpd = ac.v_y * float(FT_p_MIN_per_M_p_S);
                     XPLMSetDatavf(drTcasVertSpeed, &vertSpd, int(slot), 1);
                 }
                 ac.prev_x = ac.drawInfo.x;
@@ -623,17 +623,50 @@ void AIAssignSlots (size_t fromSlot, size_t toSlot)
 #ifdef DEBUG
     // it is expected that the range of slots is exactly filled
     // and all planes are used!
-    if (!(std::all_of(gSlots.begin()+(long)fromSlot,
-                           gSlots.begin()+(long)toSlot,
-                           [](const Aircraft* pAc){return pAc!=nullptr;})))
     {
-        LOG_MSG(logDEBUG, "Not all gSlots continuously assigned!");
-    }
-    if (!(std::all_of(vAcByDist.begin()+(long)fromSlot-1,
-                           vAcByDist.begin()+(long)toSlot-1,
-                           [](const Aircraft* pAc){return pAc==nullptr;})))
-    {
-        LOG_MSG(logDEBUG, "Not all vAcByDist used!");
+        std::string msg;
+        char s[100];
+        const Aircraft* pAc = nullptr;
+        if (!(std::all_of(gSlots.begin()+(long)fromSlot,
+                          gSlots.begin()+(long)toSlot,
+                          [](const Aircraft* pAc){return pAc!=nullptr;})))
+        {
+            msg.clear();
+            for (size_t slot = fromSlot; slot <= toSlot; ++slot)
+            {
+                pAc = gSlots[slot];
+                if (pAc)
+                    snprintf(s, sizeof(s), "%zu. %u, ", slot, pAc->GetModeS_ID());
+                else
+                    snprintf(s, sizeof(s), "%zu. <null>, ", slot);
+                msg += s;
+            }
+            if (msg.length() >= 2) {
+                msg.pop_back();
+                msg.pop_back();
+            }
+            LOG_MSG(logDEBUG, "Not all gSlots continuously assigned!\n%s", msg.c_str());
+        }
+        if (!(std::all_of(vAcByDist.begin()+(long)fromSlot-1,
+                          vAcByDist.begin()+(long)toSlot-1,
+                          [](const Aircraft* pAc){return pAc==nullptr;})))
+        {
+            msg.clear();
+            for (size_t slot = fromSlot-1; slot <= toSlot-1; ++slot)
+            {
+                pAc = vAcByDist[slot];
+                if (pAc)
+                    snprintf(s, sizeof(s), "%zu. %u, ", slot+1, pAc->GetModeS_ID());
+                else
+                    snprintf(s, sizeof(s), "%zu. <null>, ", slot+1);
+                msg += s;
+            }
+            if (msg.length() >= 2) {
+                msg.pop_back();
+                msg.pop_back();
+            }
+            LOG_MSG(logDEBUG, "Not all vAcByDist used!\n%s", msg.c_str());
+        }
     }
 #endif
 }

--- a/src/Aircraft.cpp
+++ b/src/Aircraft.cpp
@@ -862,7 +862,7 @@ void Aircraft::SetInvalid()
 
     // Set the flag
     bValid = false;
-    LOG_MSG(logERR, ERR_SET_INVALID, modeS_id);
+    LOG_MSG(logDEBUG, ERR_SET_INVALID, modeS_id);
 
     // Cleanup the object as good as possible
     try {

--- a/src/Aircraft.cpp
+++ b/src/Aircraft.cpp
@@ -118,6 +118,9 @@ std::vector<XPLMDataRef> ahDataRefs;
 /// Standard name for "no model"
 static std::string noMdlName("<none>");
 
+/// Base time for storing time differences for calculating cartesian speeds
+static const std::chrono::system_clock::time_point baseTimePt = std::chrono::system_clock::now();
+
 //
 // MARK: Wake Support
 //
@@ -513,7 +516,9 @@ float Aircraft::FlightLoopCB(float _elapsedSinceLastCall, float, int _flCounter,
     try {
         glob.xpCycleNum=XPLMGetCycleNumber();               // Store current cycle number in glob.xpCycleNum
         const float now = UpdateCachedValuesGetNetwTime();  // As this is a main thread call, let's update some values we can get only now
-
+        // Seconds passed since plugin load
+        const float secSinceBase = std::chrono::duration<float>(std::chrono::system_clock::now() - baseTimePt).count();
+        
         // Update configuration
         glob.UpdateCfgVals();
 
@@ -544,7 +549,7 @@ float Aircraft::FlightLoopCB(float _elapsedSinceLastCall, float, int _flCounter,
                     if (ac.bClampToGround || glob.bClampAll)
                         ac.ClampToGround();
                     // Do some expensive stuff every second only
-                    ac.DoEverySecondUpdates(now);
+                    ac.DoEverySecondUpdates(now, secSinceBase);
                     // If required reset touch down animation
                     if (!std::isnan(ac.tsResetTouchDown) && (now >= ac.tsResetTouchDown)) {
                         ac.SetTouchDown(false);
@@ -605,14 +610,20 @@ void Aircraft::DoMove ()
 }
 
 // Processes once every second only stuff that doesn't require being computed every flight loop
-void Aircraft::DoEverySecondUpdates (float now)
+void Aircraft::DoEverySecondUpdates (float now, float secSinceBase)
 {
-    // Update plane's distance/bearing every second only
+    // Update plane's distance/bearing every second only (XP's network time)
     if (CheckEverySoOften(camTimLstUpd, 1.0f, now)) {
         GetLocation(lat1s, lon1s, alt1s_ft);        // convert position
         UpdateDistBearingCamera(glob.posCamera);
         ComputeMapLabel();
         ContrailAutoUpdate();
+    }
+    
+    // Update velocities also every second (CPU time)
+    const float actual_prev_ts = prev_ts;
+    if (CheckEverySoOften(prev_ts, 1.0f, secSinceBase)) {
+        UpdateVelocities(prev_ts - actual_prev_ts);
     }
 }
 
@@ -656,6 +667,28 @@ void Aircraft::UpdateDistBearingCamera (const XPLMCameraPosition_t& posCam)
                       drawInfo.x, drawInfo.y, drawInfo.z);
     // Bearing (note: x points east, z points south
     camBearing = angleLocCoord(posCam.x, posCam.z, drawInfo.x, drawInfo.z);
+}
+
+/// Internal: Update cartesian velocities (about every second)
+void Aircraft::UpdateVelocities (float d_t)
+{
+    // Shouldn't divide by zero, and with reasonable distances only
+    if (0.000001f < d_t && d_t < 5.0f)
+    {
+        // Update velocities based on distance since last check
+        v_x = (drawInfo.x - prev_x) / d_t;
+        v_y = (drawInfo.y - prev_y) / d_t;
+        v_z = (drawInfo.z - prev_z) / d_t;
+        
+        // based on horizontal velocities calculate a (rough) ground speed
+        gs_kn = std::hypot(v_x, v_z) * float(KT_per_M_per_S);
+        
+        // these new values need to be written out to TCAS targets
+        bWriteTCASDataRefs = true;
+    }
+    prev_x = drawInfo.x;
+    prev_y = drawInfo.y;
+    prev_z = drawInfo.z;
 }
 
 

--- a/src/CSLModels.cpp
+++ b/src/CSLModels.cpp
@@ -1200,7 +1200,7 @@ IteratorT iterRnd (IteratorT lower, IteratorT upper)
         return lower;
     // Contains more than one, so make a random choice
     const float rnd = float(std::rand()) / float(RAND_MAX); // should be less than 1.0
-    const long adv = long(rnd * dist);                      // therefor, should be less than `dist`
+    const long adv = long(rnd * float(dist));               // therefor, should be less than `dist`
     if (adv < dist)                                         // but let's make sure
         std::advance(lower, long(adv));
     else

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -626,9 +626,9 @@ long SocketNetworking::recv(std::string* _pFromAddr,
     socklen_t   fromlen = sizeof(safrom);
     long ret =
 #if IBM
-    (long) recvfrom(f_socket, buf, (int)bufSize, 0, &safrom.sa, &fromlen);
+    (long) recvfrom(f_socket, buf, (int)bufSize-1, 0, &safrom.sa, &fromlen);
 #else
-    recvfrom(f_socket, buf, bufSize, 0, &safrom.sa, &fromlen);
+    recvfrom(f_socket, buf, bufSize-1, 0, &safrom.sa, &fromlen);
 #endif
     if (ret >= 0)  {                    // we did receive something
         buf[ret] = 0;                   // zero-termination

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -763,9 +763,9 @@ std::string GetMiscNetwTimeStr (float _time)
         _time = GetMiscNetwTime();
     
     const unsigned runH = unsigned(_time / 3600.0f);
-    _time -= runH * 3600.0f;
+    _time -= float(runH) * 3600.0f;
     const unsigned runM = unsigned(_time / 60.0f);
-    _time -= runM * 60.0f;
+    _time -= float(runM) * 60.0f;
     
     snprintf(aszTimeStr, sizeof(aszTimeStr), "%u:%02u:%06.3f",
              runH, runM, _time);

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -235,6 +235,9 @@ void GlobVars::UpdateCfgVals ()
     // Ask for model matching logging
     bLogMdlMatch = prefsFuncInt(XPMP_CFG_SEC_DEBUG, XPMP_CFG_ITM_MODELMATCHING, bLogMdlMatch) != 0;
     
+    // Update other XP features that we may need (also from threads)
+    bXPUseNativePaths = XPLMIsFeatureEnabled("XPLM_USE_NATIVE_PATHS");
+
     // Fetch the network / multiplayer setup from X-Plane, which theoretically can change over time
     static XPLMDataRef drIsExternalVisual       = XPLMFindDataRef("sim/network/dataout/is_external_visual");        // int/boolean
     static XPLMDataRef drIsMultiplayer          = XPLMFindDataRef("sim/network/dataout/is_multiplayer_session");    // int/boolean

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -294,6 +294,9 @@ void GlobVars::ReadVersions ()
         bXPUsingModernGraphicsDriver = XPLMGetDatai(drUsingModernDriver) != 0;
     else
         bXPUsingModernGraphicsDriver = false;
+    
+    // and other XP features that we may need (also from threads)
+    bXPUseNativePaths = XPLMIsFeatureEnabled("XPLM_USE_NATIVE_PATHS");
 }
 
 
@@ -569,7 +572,7 @@ bool Posix2HFSPath(const char *path, char *result, int resultSize)
 std::string TOPOSIX (const std::string& p)
 {
     // no actual conversion if XPLM_USE_NATIVE_PATHS is activated
-    if (XPLMIsFeatureEnabled("XPLM_USE_NATIVE_PATHS"))
+    if (glob.bXPUseNativePaths)
         return p;
     else {
         char posix[1024];
@@ -584,7 +587,7 @@ std::string TOPOSIX (const std::string& p)
 std::string FROMPOSIX (const std::string& p)
 {
     // no actual conversion if XPLM_USE_NATIVE_PATHS is activated
-    if (XPLMIsFeatureEnabled("XPLM_USE_NATIVE_PATHS"))
+    if (glob.bXPUseNativePaths)
         return p;
     else {
         char hfs[1024];

--- a/src/XPMP2.h
+++ b/src/XPMP2.h
@@ -63,6 +63,7 @@
 #include <shared_mutex>
 #include <regex>
 #include <bitset>
+#include <chrono>
 
 // FMOD Sound, must be included before XPLMSound.h
 #if INCLUDE_FMOD_SOUND + 0 >= 1

--- a/src/XPMP2.h
+++ b/src/XPMP2.h
@@ -262,6 +262,8 @@ public:
     int             verXPLM = -1;
     /// Using a modern graphics driver, ie. Vulkan/Metal?
     bool            bXPUsingModernGraphicsDriver = false;
+    /// Native path feature enabled?
+    bool            bXPUseNativePaths = false;
     /// Is X-Plane configured for networked multi-computer or multiplayer setup?
     bool            bXPNetworkedSetup = false;
     /// This plugin's id


### PR DESCRIPTION
- Removed `XPLMIsFeatureEnabled` from use in CSL object loading thread
- Fixed a potential memory overrun in `SocketNetworking::recv`
- Fixed computation of cartesian velocities, now for all planes (previously only planes on TCAS target slots)